### PR TITLE
services: add forgejo to octavian

### DIFF
--- a/data/service-registry.nix
+++ b/data/service-registry.nix
@@ -173,4 +173,9 @@ rec {
   vllm = {
     port = 11080;
   };
+
+  forgejo = {
+    domain = "git.breakds.org";
+    port = 5970;
+  };
 }

--- a/machines/octavian/default.nix
+++ b/machines/octavian/default.nix
@@ -31,6 +31,7 @@
     ./services/stt-server.nix
     ./services/toylet-notes.nix
     ./services/tiny-share.nix
+    ./services/forgejo.nix
     ../../base/vpn.nix
   ];
 

--- a/machines/octavian/services/forgejo.nix
+++ b/machines/octavian/services/forgejo.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+let
+  registry = (import ../../../data/service-registry.nix).forgejo;
+in {
+  services.forgejo = {
+    enable = true;
+
+    database = {
+      type = "postgres";
+      host = "unix:/run/postgresql";
+      name = "forgejo";
+      user = "forgejo";
+      createDatabase = true;
+    };
+
+    settings = {
+      server = {
+        HTTP_ADDR = "127.0.0.1";
+        HTTP_PORT = registry.port;
+        DOMAIN = registry.domain;
+        ROOT_URL = "https://${registry.domain}";
+        # Use host's sshd for git operations.
+        # START_SSH_SERVER = true is a workaround for the module state machine:
+        # it prevents the module from overriding openssh settings (AcceptEnv),
+        # while DISABLE_SSH = true tells Forgejo not to start its own SSH server.
+        # Net result: git SSH goes through port 22 via host sshd, and the module
+        # still manages authorized_keys for the forgejo user.
+        START_SSH_SERVER = true;
+        DISABLE_SSH = true;
+        SSH_PORT = 22;
+      };
+      # Disable open registration — admin creates accounts only
+      service = {
+        DISABLE_REGISTRATION = true;
+      };
+    };
+  };
+
+  services.nginx.virtualHosts."${registry.domain}" = {
+    enableACME = true;
+    forceSSL = true;
+    locations."/" = {
+      proxyPass = "http://localhost:${toString registry.port}";
+    };
+  };
+}

--- a/machines/octavian/services/forgejo.nix
+++ b/machines/octavian/services/forgejo.nix
@@ -55,6 +55,12 @@ in {
       service = {
         DISABLE_REGISTRATION = true;
       };
+
+      # TLS terminates at nginx, so Forgejo sees plain HTTP and won't set the
+      # Secure flag on session cookies on its own. Force it on.
+      session = {
+        COOKIE_SECURE = true;
+      };
     };
   };
 

--- a/machines/octavian/services/forgejo.nix
+++ b/machines/octavian/services/forgejo.nix
@@ -3,13 +3,29 @@
 let
   registry = (import ../../../data/service-registry.nix).forgejo;
 in {
+  /*
+   * Forgejo (self-hosted Git) service configuration:
+   *
+   * System user: forgejo (default, used for process execution and file ownership)
+   * PostgreSQL:  forgejo/forgejo db+user (created via NixOS declarative config)
+   * SSH clone:   git@... (SSH_USER = "git" for familiar clone URLs)
+   *
+   * The SSH_USER display name is "git" while the actual system user is "forgejo".
+   * sshd authenticates via the managed authorized_keys file, not the URL username.
+   * Users clone with: git clone git@git.breakds.org:owner/repo.git
+   */
+
   services.forgejo = {
     enable = true;
 
+    # Enable git-lfs for large file support
     lfs = {
       enable = true;
     };
 
+    # PostgreSQL backend via local Unix socket (peer auth, no password needed).
+    # NixOS module creates the database and user declaratively on first boot.
+    # Assertion requires db user == db name when auto-creating.
     database = {
       type = "postgres";
       host = "unix:/run/postgresql";
@@ -24,14 +40,17 @@ in {
         HTTP_PORT = registry.port;
         DOMAIN = registry.domain;
         ROOT_URL = "https://${registry.domain}";
-        # Use host's sshd for git operations.
-        # DISABLE_SSH = true tells Forgejo not to start its own SSH server.
-        # The NixOS module sets AcceptEnv GIT_PROTOCOL on the host sshd for
-        # CVE-2023-27655 mitigation. Git SSH goes through port 22 via host sshd,
-        # and Forgejo manages authorized_keys for the forgejo user.
-        DISABLE_SSH = true;
+
+        # Git over SSH: clone URL is git@git.breakds.org:owner/repo.git
+        # Forgejo does NOT start its own SSH server — it uses the host's sshd.
+        # Users add their SSH public key in Forgejo's web UI, and Forgejo writes
+        # it to the authorized_keys file for the "forgejo" system user.
+        # The host's sshd authenticates the connection, and Forgejo handles the git
+        # operation via the command= prefix in authorized_keys.
+        SSH_USER = "git";  # displayed in clone URLs (e.g. git@git.breakds.org)
         SSH_PORT = 22;
       };
+
       # Disable open registration — admin creates accounts only
       service = {
         DISABLE_REGISTRATION = true;

--- a/machines/octavian/services/forgejo.nix
+++ b/machines/octavian/services/forgejo.nix
@@ -6,6 +6,10 @@ in {
   services.forgejo = {
     enable = true;
 
+    lfs = {
+      enable = true;
+    };
+
     database = {
       type = "postgres";
       host = "unix:/run/postgresql";

--- a/machines/octavian/services/forgejo.nix
+++ b/machines/octavian/services/forgejo.nix
@@ -21,12 +21,10 @@ in {
         DOMAIN = registry.domain;
         ROOT_URL = "https://${registry.domain}";
         # Use host's sshd for git operations.
-        # START_SSH_SERVER = true is a workaround for the module state machine:
-        # it prevents the module from overriding openssh settings (AcceptEnv),
-        # while DISABLE_SSH = true tells Forgejo not to start its own SSH server.
-        # Net result: git SSH goes through port 22 via host sshd, and the module
-        # still manages authorized_keys for the forgejo user.
-        START_SSH_SERVER = true;
+        # DISABLE_SSH = true tells Forgejo not to start its own SSH server.
+        # The NixOS module sets AcceptEnv GIT_PROTOCOL on the host sshd for
+        # CVE-2023-27655 mitigation. Git SSH goes through port 22 via host sshd,
+        # and Forgejo manages authorized_keys for the forgejo user.
         DISABLE_SSH = true;
         SSH_PORT = 22;
       };


### PR DESCRIPTION
Minimal Forgejo (self-hosted Git) service on octavian:
- PostgreSQL backend via local socket
- Host sshd for git (port 22), no separate SSH server
- nginx reverse proxy with ACME TLS
- Domain: git.breakds.org:5970
- Registration disabled (admin creates accounts only)